### PR TITLE
Add getLoginPacket method

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -274,6 +274,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected $randomClientId;
 	/** @var string */
 	protected $xuid = "";
+	/** @var LoginPacket */
+	protected $loginPacket;
 
 	protected $windowCnt = 2;
 	/** @var int[] */
@@ -824,6 +826,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 */
 	public function getLocale() : string{
 		return $this->locale;
+	}
+	
+	/**
+      * @return LoginPacket
+	  */
+	public function getLoginPacket() : LoginPacket{
+		return $this->loginPacket;
 	}
 
 	/**
@@ -1896,6 +1905,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->username = TextFormat::clean($packet->username);
 		$this->displayName = $this->username;
 		$this->iusername = strtolower($this->username);
+		$this->loginPacket = $packet;
 
 		if($packet->locale !== null){
 			$this->locale = $packet->locale;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As we know, we can handling this on DataPacketReceiveEvent. But we need alternative method to getting LoginPacket of player without creating Event.

## Changes
<!-- Any additions to the API that should be documented in release notes? -->
Add method getLoginPacket on Player class.
